### PR TITLE
Support <-debouncer.Done()

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ debouncer.SendSignal()
 Allows the caller of godebouncer knows when the triggered function is done invoking to synchronize execution across goroutines.
 
 ```go
-debouncer := godebouncer.new(1 * time.Second).WithTriggered(func() {
+debouncer := godebouncer.New(1 * time.Second).WithTriggered(func() {
 	fmt.Println("Fetching...")
 	time.Sleep(2 * time.Second)
 	fmt.Println("Done")

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ func main() {
 
 	fmt.Println("Action 2")
 	debouncer.SendSignal()
+
 	// After 5 seconds, the trigger will be called.
 	// Previous `SendSignal()` will be ignored to trigger the triggered function.
-
-	time.Sleep(10 * time.Second)
+	<-debouncer.Done()
 }
 ```
 
@@ -109,6 +109,24 @@ debouncer := godebouncer.New(wait).WithTriggered(func() {
 debouncer.UpdateTimeDuration(20 * time.Millisecond)
 debouncer.SendSignal()
 // Output: "Trigger" after 20 seconds
+```
+
+## Let the main goroutine knows when the triggered function is invoked
+
+Allows the caller of godebouncer knows when the triggered function is invoked to synchronize execution across goroutines.
+
+```go
+wait := 1 * time.Second
+debouncer := godebouncer.new(wait).WithTriggered(func() {
+	fmt.Println("Fetching...")
+	time.Sleep(2 * time.Second)
+	fmt.Println("Done")
+})
+
+debouncer.SendSignal()
+<-debouncer.Done() // The current goroutine will wait until the triggered func finish its execution.
+
+fmt.Println("After done")
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ debouncer.SendSignal()
 // Output: "Trigger" after 20 seconds
 ```
 
-## Let the main goroutine knows when the triggered function is invoked
+## Let the caller knows when the triggered function has been invoked
 
-Allows the caller of godebouncer knows when the triggered function is invoked to synchronize execution across goroutines.
+Allows the caller of godebouncer knows when the triggered function is done invoking to synchronize execution across goroutines.
 
 ```go
 wait := 1 * time.Second
@@ -124,6 +124,7 @@ debouncer := godebouncer.new(wait).WithTriggered(func() {
 })
 
 debouncer.SendSignal()
+
 <-debouncer.Done() // The current goroutine will wait until the triggered func finish its execution.
 
 fmt.Println("After done")

--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ debouncer.SendSignal()
 Allows the caller of godebouncer knows when the triggered function is done invoking to synchronize execution across goroutines.
 
 ```go
-wait := 1 * time.Second
-debouncer := godebouncer.new(wait).WithTriggered(func() {
+debouncer := godebouncer.new(1 * time.Second).WithTriggered(func() {
 	fmt.Println("Fetching...")
 	time.Sleep(2 * time.Second)
 	fmt.Println("Done")

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ From your code, you can try to create debouncer.
 package main
 
 func main() {
-	wait := 5 * time.Second
-	debouncer := godebouncer.New(wait).WithTriggered(func() {
+	debouncer := godebouncer.New(5 * time.Second).WithTriggered(func() {
 		fmt.Println("Trigger") // Triggered func will be called after 5 seconds from last SendSignal().
 	})
 
@@ -52,8 +51,7 @@ func main() {
 Allows defining actions before calling SendSignal(). They are synchronous.
 
 ```go
-wait := 10 * time.Second
-debouncer := godebouncer.New(wait).WithTriggered(func() {
+debouncer := godebouncer.New(10 * time.Second).WithTriggered(func() {
 	fmt.Println("Trigger") // Triggered func will be called after 10 seconds from last SendSignal().
 })
 
@@ -69,8 +67,7 @@ debouncer.Do(func() {
 Allows cancelling the timer from the last function SendSignal(). The scheduled triggered function is cancelled and doesn't invoke.
 
 ```go
-wait := 10 * time.Second
-debouncer := godebouncer.New(wait).WithTriggered(func() {
+debouncer := godebouncer.New(10 * time.Second).WithTriggered(func() {
 	fmt.Println("Trigger") // Triggered func will be called after 10 seconds from last SendSignal().
 })
 
@@ -83,8 +80,7 @@ debouncer.Cancel() // No triggered function is called
 Allows replacing triggered function.
 
 ```go
-wait := 10 * time.Second
-debouncer := godebouncer.New(wait).WithTriggered(func() {
+debouncer := godebouncer.New(10 * time.Second).WithTriggered(func() {
 	fmt.Println("Trigger 1") // Triggered func will be called after 10 seconds from last SendSignal().
 })
 
@@ -101,8 +97,7 @@ debouncer.UpdateTriggeredFunc(func() {
 Allows replacing the waiting time duration. You need to call a SendSignal() again to trigger a new timer with a new waiting time duration.
 
 ```go
-wait := 10 * time.Second
-debouncer := godebouncer.New(wait).WithTriggered(func() {
+debouncer := godebouncer.New(10 * time.Second).WithTriggered(func() {
 	fmt.Println("Trigger") // Triggered func will be called after 10 seconds from last SendSignal().
 })
 

--- a/debouncer.go
+++ b/debouncer.go
@@ -47,6 +47,7 @@ func (d *Debouncer) Cancel() {
 	if d.timer != nil {
 		d.timer.Stop()
 	}
+	d.done = make(chan struct{})
 }
 
 // UpdateTriggeredFunc replaces triggered function.

--- a/debouncer.go
+++ b/debouncer.go
@@ -10,12 +10,12 @@ type Debouncer struct {
 	timer         *time.Timer
 	triggeredFunc func()
 	mu            sync.Mutex
-	done          chan bool
+	done          chan struct{}
 }
 
 // New creates a new instance of debouncer. Each instance of debouncer works independent, concurrency with different wait duration.
 func New(duration time.Duration) *Debouncer {
-	return &Debouncer{timeDuration: duration, triggeredFunc: func() {}, done: make(chan bool, 1)}
+	return &Debouncer{timeDuration: duration, triggeredFunc: func() {}, done: make(chan struct{}, 1)}
 }
 
 // WithTriggered attached a triggered function to debouncer instance and return the same instance of debouncer to use.
@@ -32,7 +32,7 @@ func (d *Debouncer) SendSignal() {
 	d.Cancel()
 	d.timer = time.AfterFunc(d.timeDuration, func() {
 		d.triggeredFunc()
-		d.done <- true
+		d.done <- struct{}{}
 	})
 }
 
@@ -60,6 +60,6 @@ func (d *Debouncer) UpdateTimeDuration(newTimeDuration time.Duration) {
 }
 
 // Done returns a receive-only channel to notify the caller when the triggered func is invoked.
-func (d *Debouncer) Done() <-chan bool {
+func (d *Debouncer) Done() <-chan struct{} {
 	return d.done
 }

--- a/debouncer.go
+++ b/debouncer.go
@@ -15,7 +15,7 @@ type Debouncer struct {
 
 // New creates a new instance of debouncer. Each instance of debouncer works independent, concurrency with different wait duration.
 func New(duration time.Duration) *Debouncer {
-	return &Debouncer{timeDuration: duration, triggeredFunc: func() {}, done: make(chan struct{}, 1)}
+	return &Debouncer{timeDuration: duration, triggeredFunc: func() {}, done: make(chan struct{})}
 }
 
 // WithTriggered attached a triggered function to debouncer instance and return the same instance of debouncer to use.

--- a/debouncer.go
+++ b/debouncer.go
@@ -32,9 +32,7 @@ func (d *Debouncer) SendSignal() {
 	d.Cancel()
 	d.timer = time.AfterFunc(d.timeDuration, func() {
 		d.triggeredFunc()
-		go func() {
-			d.done <- true
-		}()
+		d.done <- true
 	})
 }
 

--- a/debouncer.go
+++ b/debouncer.go
@@ -60,7 +60,7 @@ func (d *Debouncer) UpdateTimeDuration(newTimeDuration time.Duration) {
 	d.timeDuration = newTimeDuration
 }
 
-// Done returns a receive-only channel to notify the caller when the triggered func is invoked.
+// Done returns a receive-only channel to notify the caller when the triggered func has been executed.
 func (d *Debouncer) Done() <-chan struct{} {
 	return d.done
 }

--- a/debouncer_test.go
+++ b/debouncer_test.go
@@ -212,12 +212,21 @@ func TestDebounceUpdateDurationAfterSendSignal(t *testing.T) {
 }
 
 func TestDone(t *testing.T) {
-	debouncer := godebouncer.New(200 * time.Millisecond).WithTriggered(func() {
-		fmt.Println("Triggered")
-	})
+	countPtr, incrementCount := createIncrementCount(0)
+	debouncer := godebouncer.New(200 * time.Millisecond).WithTriggered(incrementCount)
+	expectedCounter := int(2)
 
+	fmt.Println("Action 1")
+	debouncer.SendSignal()
+	time.Sleep(400 * time.Millisecond)
+
+	fmt.Println("Action 2")
 	debouncer.SendSignal()
 	<-debouncer.Done()
 
-	fmt.Println("Debouncer has done signalling")
+	fmt.Println(len(debouncer.Done()))
+
+	if *countPtr != expectedCounter {
+		t.Errorf("Expected count %d, was %d", expectedCounter, *countPtr)
+	}
 }

--- a/debouncer_test.go
+++ b/debouncer_test.go
@@ -219,5 +219,5 @@ func TestDone(t *testing.T) {
 	debouncer.SendSignal()
 	<-debouncer.Done()
 
-	fmt.Println("debouncer has done signalling")
+	fmt.Println("Debouncer has done signalling")
 }

--- a/debouncer_test.go
+++ b/debouncer_test.go
@@ -217,9 +217,7 @@ func TestDone(t *testing.T) {
 	})
 
 	debouncer.SendSignal()
-	done := <-debouncer.Done()
+	<-debouncer.Done()
 
-	if done != true {
-		t.Errorf("Expected done %t, was %t", true, done)
-	}
+	fmt.Println("debouncer has done signalling")
 }


### PR DESCRIPTION
The caller can now use `<-debouncer.Done()` channel to knows when the triggered function is done invoking.

```go
wait := 1 * time.Second
debouncer := godebouncer.new(wait).WithTriggered(func() {
	fmt.Println("Fetching...")
	time.Sleep(2 * time.Second)
	fmt.Println("Done")
})

debouncer.SendSignal()
<-debouncer.Done() // The current goroutine will wait until the triggered func finish its execution.

fmt.Println("After done")
```

Address https://github.com/vnteamopen/godebouncer/issues/19.