### PR TITLE
fix: Fix race condition on channel

### DIFF
--- a/debouncer.go
+++ b/debouncer.go
@@ -119,6 +119,8 @@ func (d *Debouncer) invokeTriggeredFunc() *time.Timer {
 	d.signalCalledAt = time.Now()
 
 	return time.AfterFunc(d.timeDuration, func() {
+		d.mu.Lock()
+		defer d.mu.Unlock()
 		d.triggeredFunc()
 		if d.done != nil {
 			close(d.done)
@@ -170,6 +172,8 @@ func (d *Debouncer) UpdateTimeDuration(newTimeDuration time.Duration) {
 
 // Done returns a receive-only channel to notify the caller when the triggered func has been executed.
 func (d *Debouncer) Done() <-chan struct{} {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.done == nil {
 		d.done = make(chan struct{})
 	}


### PR DESCRIPTION
This should fix two issues:

```
panic: close of closed channel

goroutine 1337 [running]:
github.com/vnteamopen/godebouncer.(*Debouncer).invokeTriggeredFunc.func1()
	/home/runner/go/pkg/mod/github.com/vnteamopen/godebouncer@v1.1.1-0.20230626172639-4b59d27e1b8c/debouncer.go:124 +0x85
created by time.goFunc
	/opt/hostedtoolcache/go/1.21.5/x64/src/time/sleep.go:176 +0x45
```

and a data race, as can be seen in the CI build [here](https://github.com/cloudquery/cloudquery/actions/runs/7975461527/job/21773758305#step:6:31).